### PR TITLE
Install required Debian package ros-kinetic-tf2-bullet.

### DIFF
--- a/src/Simulator/install.sh
+++ b/src/Simulator/install.sh
@@ -44,6 +44,7 @@ sudo apt-get install ros-kinetic-ackermann-msgs
 sudo apt-get install python3-yaml
 sudo apt-get install python3-catkin-pkg-modules
 sudo apt-get install python3-rospkg-modules
+sudo apt-get install ros-kinetic-tf2-bullet
 
 # Build 
 catkin_make


### PR DESCRIPTION
ros-kinetic-tf2-bullet was necessary for `catkin_make` to finish.